### PR TITLE
Fixed broken hyperlink to Little Spoon Farm

### DIFF
--- a/episodes/recipe_intro.md
+++ b/episodes/recipe_intro.md
@@ -17,7 +17,7 @@ exercises: 2
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-We will be describing [Little Spoon Farm's](https://littlespoonsfarm.com/) delicious [sourdough cinnamon roll recipe](https://littlespoonfarm.com/sourdough-cinnamon-rolls/). The sourdough imparts a slightly tangy, fruity quality that complements the cinnamon flavor of the rolls. However, it does take slightly more work and time than a standard cinnamon roll recipe that uses dry yeast. Additionally, you'll need to have some sourdough starter already going; alternatively, you can pester a friend for some of theirs, or [make your own](https://www.kingarthurbaking.com/recipes/sourdough-starter-recipe).
+We will be describing [Little Spoon Farm's](https://littlespoonfarm.com/) delicious [sourdough cinnamon roll recipe](https://littlespoonfarm.com/sourdough-cinnamon-rolls/). The sourdough imparts a slightly tangy, fruity quality that complements the cinnamon flavor of the rolls. However, it does take slightly more work and time than a standard cinnamon roll recipe that uses dry yeast. Additionally, you'll need to have some sourdough starter already going; alternatively, you can pester a friend for some of theirs, or [make your own](https://www.kingarthurbaking.com/recipes/sourdough-starter-recipe).
 
 ![](fig/cinnamon-rolls-out-of-the-oven.jpg){alt='A bunch of baked cinnamon rolls in a baking tray.'}
 


### PR DESCRIPTION
Fixes Issue #10
The link to Little Spoon Farm had an extra s in it. It was changed to https://littlespoonfarm.com/.